### PR TITLE
Add matrix-based LED grid for simulation

### DIFF
--- a/src/led.cpp
+++ b/src/led.cpp
@@ -1,4 +1,5 @@
 #include "led.h"
+#include "matrix.h"
 
 Led::Led()
 {
@@ -294,5 +295,27 @@ void Led::lightLeds(int16_t reviews, int16_t lessons)
     // leds[ XY(2, 2) ].setHSV(HUE_LESSON, 255, 255);
 
     // printLeds();
+    FastLED.show();
+}
+
+void Led::displayMatrix(const Matrix& matrix)
+{
+    for (uint8_t x = 0; x < MATRIX_WIDTH; ++x)
+    {
+        for (uint8_t y = 0; y < MATRIX_HEIGHT; ++y)
+        {
+            Cell cell = matrix.getCell(x, y);
+            CRGB color = CRGB::Black;
+            if (cell.type == CELL_LESSON)
+            {
+                color.setHSV(HUE_LESSON, S, V);
+            }
+            else if (cell.type == CELL_REVIEW)
+            {
+                color.setHSV(HUE_REVIEW, S, V);
+            }
+            leds[XY(x, y)] = color;
+        }
+    }
     FastLED.show();
 }

--- a/src/led.h
+++ b/src/led.h
@@ -5,6 +5,8 @@
 #include <FastLED.h>
 #include "utils.h"
 
+class Matrix; // forward declaration
+
 class Led {
 
 private:
@@ -63,7 +65,7 @@ private:
         return arr;
     }
     const uint8_t* xIterOrder = genXIterOrder();
-    
+
 
     void setup();
     uint16_t scaleToLeds(uint16_t num);
@@ -98,12 +100,13 @@ public:
     void clearAll();
     uint16_t XY(uint8_t x, uint8_t y);
     CRGB leds[NUM_LEDS]; // LED array
-    
+
     // Helper methods for direct LED manipulation
     void setPixelColor(uint8_t x, uint8_t y, uint8_t r, uint8_t g, uint8_t b);
     void showLeds();
     void testPattern();
-    
+    void displayMatrix(const Matrix& matrix);
+
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "wanikani.h"
 #include "utils.h"
 #include "led.h"
+#include "matrix.h"
 
 // configure WiFi etc. in config.h
 
@@ -16,6 +17,7 @@ int16_t lastReviews = -1;
 int16_t lastLessons = -1;
 WaniKani wk(API_KEY);
 Led led = Led();
+Matrix matrix;
 
 void setup()
 {
@@ -69,7 +71,22 @@ void loop()
     Serial.println((String)"FreeHeap: " + ESP.getFreeHeap()/1024);
 
     Serial.println();
-    led.lightLeds(wk.getReviews(), wk.getLessons());
+
+    matrix.clear();
+    int idx = 0;
+    auto place = [&](CellType type, uint32_t availableAt, int count)
+    {
+        for (int i = 0; i < count && idx < MATRIX_WIDTH * MATRIX_HEIGHT; ++i, ++idx)
+        {
+            uint8_t x = idx % MATRIX_WIDTH;
+            uint8_t y = idx / MATRIX_WIDTH;
+            matrix.setCell(x, y, type, availableAt);
+        }
+    };
+    place(CELL_LESSON, 0, wk.getLessons());
+    place(CELL_REVIEW, 0, wk.getReviews());
+    place(CELL_REVIEW, 1, wk.getReviews(1));
+    led.displayMatrix(matrix);
 
     // sleep(10);
 }

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -1,0 +1,32 @@
+#include "matrix.h"
+
+Matrix::Matrix()
+{
+    clear();
+}
+
+void Matrix::clear()
+{
+    for (uint8_t x = 0; x < MATRIX_WIDTH; ++x)
+    {
+        for (uint8_t y = 0; y < MATRIX_HEIGHT; ++y)
+        {
+            cells[x][y] = Cell();
+        }
+    }
+}
+
+void Matrix::setCell(uint8_t x, uint8_t y, CellType type, uint32_t availableAt)
+{
+    if (x >= MATRIX_WIDTH || y >= MATRIX_HEIGHT)
+        return;
+    cells[x][y].type = type;
+    cells[x][y].availableAt = availableAt;
+}
+
+Cell Matrix::getCell(uint8_t x, uint8_t y) const
+{
+    if (x >= MATRIX_WIDTH || y >= MATRIX_HEIGHT)
+        return Cell();
+    return cells[x][y];
+}

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -1,0 +1,35 @@
+#ifndef MATRIX_H
+#define MATRIX_H
+
+#include <Arduino.h>
+#include "led.h"
+
+enum CellType
+{
+    CELL_EMPTY,
+    CELL_LESSON,
+    CELL_REVIEW
+};
+
+struct Cell
+{
+    CellType type = CELL_EMPTY;
+    uint32_t availableAt = 0; // hour when available
+};
+
+class Matrix
+{
+public:
+    Matrix();
+    void clear();
+    void setCell(uint8_t x, uint8_t y, CellType type, uint32_t availableAt);
+    Cell getCell(uint8_t x, uint8_t y) const;
+    uint8_t width() const { return MATRIX_WIDTH; }
+    uint8_t height() const { return MATRIX_HEIGHT; }
+
+private:
+    Cell cells[MATRIX_WIDTH][MATRIX_HEIGHT];
+};
+
+#endif
+


### PR DESCRIPTION
## Summary
- introduce `Matrix` class to store per-LED metadata like lesson or review and availability
- render LED colors from matrix via new `Led::displayMatrix`
- populate matrix in `main.cpp` using WaniKani data

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dd2818f88332a38dee313c1c749d