### PR TITLE
Add local API for testing WaniKani data

### DIFF
--- a/src/local_api.cpp
+++ b/src/local_api.cpp
@@ -1,0 +1,37 @@
+#include <Arduino.h>
+#include <WebServer.h>
+#include "local_api.h"
+
+static WaniKani* g_wk = nullptr;
+static WebServer server(80);
+
+static void handleWaniKaniPost()
+{
+    if (!server.hasArg("plain"))
+    {
+        server.send(400, "text/plain", "Missing body");
+        return;
+    }
+    String body = server.arg("plain");
+    if (g_wk && g_wk->setSummaryJson(body))
+    {
+        g_wk->refresh();
+        server.send(200, "text/plain", "OK");
+    }
+    else
+    {
+        server.send(400, "text/plain", "Invalid JSON");
+    }
+}
+
+void setupLocalApi(WaniKani* wk)
+{
+    g_wk = wk;
+    server.on("/wanikani_test_data", HTTP_POST, handleWaniKaniPost);
+    server.begin();
+}
+
+void handleLocalApi()
+{
+    server.handleClient();
+}

--- a/src/local_api.h
+++ b/src/local_api.h
@@ -1,0 +1,10 @@
+#ifndef LOCAL_API_H
+#define LOCAL_API_H
+
+#include <WebServer.h>
+#include "wanikani.h"
+
+void setupLocalApi(WaniKani* wk);
+void handleLocalApi();
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,12 +3,11 @@
 #include <time.h>
 #include <HTTPClient.h>
 #include "WiFi.h"
-
-
 #include "wanikani.h"
 #include "utils.h"
 #include "led.h"
 #include "matrix.h"
+#include "local_api.h"
 
 // configure WiFi etc. in config.h
 
@@ -33,6 +32,8 @@ void setup()
 
     sleep(1);
     led.begin();
+
+    setupLocalApi(&wk);
 
 
     matrix.clear();
@@ -92,6 +93,8 @@ void loop()
     {
         wk.refresh();
     }
+
+    handleLocalApi();
 
     EVERY_N_MILLISECONDS(MILLIS_PER_FRAME)
     {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,4 +1,5 @@
 #include "utils.h"
+#include "WiFi.h"
 
 void Utils::WifiConnect()
 {
@@ -36,6 +37,7 @@ void Utils::WifiConnect()
         delay(1000);
         wifiCounter++;
     }
+    WiFi.setHostname("WaniKani Frame of enlightenment");
 
     Serial.println("");
     Serial.println("WiFi connected");

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,6 +1,8 @@
 #include "utils.h"
 #include "WiFi.h"
 
+const char* hostname = "WaniKani Frame of enlightenment";
+
 void Utils::WifiConnect()
 {
     const uint8_t retrySeconds = 60;
@@ -37,7 +39,7 @@ void Utils::WifiConnect()
         delay(1000);
         wifiCounter++;
     }
-    WiFi.setHostname("WaniKani Frame of enlightenment");
+    WiFi.setHostname(hostname);
 
     Serial.println("");
     Serial.println("WiFi connected");

--- a/src/wanikani.cpp
+++ b/src/wanikani.cpp
@@ -1,7 +1,7 @@
 #include "wanikani.h"
 #include "utils.h"
 
-WaniKani::WaniKani(const char* apiKey)
+WaniKani::WaniKani(const char* apiKey) : summaryCache(SUMMARY_JSON_SIZE)
 {
     this->apiKey = apiKey;
 }
@@ -34,15 +34,30 @@ bool WaniKani::apiRequest(String apiUrl, DynamicJsonDocument* json)
 
 DynamicJsonDocument* WaniKani::apiSummaryRequest()
 {
-    static DynamicJsonDocument cachedRequest(SUMMARY_JSON_SIZE);
+    if (overrideSummary)
+        return &summaryCache;
 
     if (this->canRequest(lastRequestTime) && Utils::WiFiConnected())
     {
         Serial.println("Caching Request Json");
-        if (this->apiRequest(this->WK_API_URL + (String)"summary", &cachedRequest))
+        if (this->apiRequest(this->WK_API_URL + (String)"summary", &summaryCache))
             lastRequestTime = millis();
     }
-    return &cachedRequest;
+    return &summaryCache;
+}
+
+bool WaniKani::setSummaryJson(const String& json)
+{
+    DeserializationError error = deserializeJson(summaryCache, json);
+    if (error)
+    {
+        Serial.print(F("WaniKani::setSummaryJson deserializeJson() failed: "));
+        Serial.println(error.f_str());
+        return false;
+    }
+    lastRequestTime = millis();
+    overrideSummary = true;
+    return true;
 }
 
 /**
@@ -122,24 +137,9 @@ int16_t WaniKani::getReviews()
 
 int16_t WaniKani::getReviews(uint8_t hour)
 {
-    if (hour == 1)
-        return 5;
-    if (hour == 2)
-        return 10;
-    if (hour == 10)
-        return 20;
-    if (hour == 11)
-        return 22;
-    if (hour == 12)
-        return 15;
-    if (hour == 23)
-        return 5;
-    if (hour == 24)
-        return 10;
     if (hour == 0)
         return this->reviews;
-    else
-        return this->getSummaryReviews(hour);
+    return this->getSummaryReviews(hour);
 }
 
 int16_t WaniKani::getLessons()

--- a/src/wanikani.h
+++ b/src/wanikani.h
@@ -19,6 +19,8 @@ private:
     const char* apiKey;
     const char* WK_API_URL = "https://api.wanikani.com/v2/";
     bool apiRequest(String apiUrl, DynamicJsonDocument* json);
+    DynamicJsonDocument summaryCache;
+    bool overrideSummary = false;
     DynamicJsonDocument* apiSummaryRequest();
     int16_t getSummaryLessons();
     int16_t getSummaryReviews(uint8_t hour=0);
@@ -29,6 +31,7 @@ private:
 
 public:
     WaniKani(const char* apiKey);
+    bool setSummaryJson(const String& json);
     int16_t getReviews();
     // get upcoming Reviews that many hours in the future
     int16_t getReviews(uint8_t hour);


### PR DESCRIPTION
## Summary
- extract local API server into its own module with a `/wanikani_test_data` POST endpoint
- wire main sketch to the new module for easier expansion
- skip online summary requests when override JSON is provided

## Testing
- `pio run -e esp32dev`


------
https://chatgpt.com/codex/tasks/task_e_68a794fb5fb483328e6f8e45f62ceb68