### PR TITLE
feat: add high-resolution matrix

### DIFF
--- a/src/led.cpp
+++ b/src/led.cpp
@@ -185,16 +185,7 @@ void Led::displayMatrix(const Matrix& matrix)
     {
         for (uint8_t y = 0; y < MATRIX_HEIGHT; ++y)
         {
-            const Cell* cell = matrix.getCell(x, y);
-            CRGB c = CRGB::Black;
-            if (cell->type != CELL_EMPTY)
-            {
-                c.setHSV(cell->hue, S, cell->value);
-            }
-            else
-            {
-                c = CRGB::Black;
-            }
+            CRGB c = matrix.getLedColor(x, y);
             target[XY(x, y)] = c;
         }
     }

--- a/src/led.h
+++ b/src/led.h
@@ -11,8 +11,16 @@
 
 
 // See: https://github.com/FastLED/FastLED/blob/master/examples/XYMatrix/XYMatrix.ino for details about the options
+// Physical matrix size in pixels
 #define MATRIX_WIDTH  10  // adjust
 #define MATRIX_HEIGHT 10  // adjust
+
+// factor by which the simulation matrix is higher resolution than the LED matrix
+#define MATRIX_RESOLUTION 10
+
+// internal high-resolution matrix dimensions
+#define MATRIX_INTERNAL_WIDTH  (MATRIX_WIDTH  * MATRIX_RESOLUTION)
+#define MATRIX_INTERNAL_HEIGHT (MATRIX_HEIGHT * MATRIX_RESOLUTION)
 
 class Matrix; // forward declaration
 

--- a/src/led.h
+++ b/src/led.h
@@ -18,6 +18,9 @@
 // factor by which the simulation matrix is higher resolution than the LED matrix
 #define MATRIX_RESOLUTION 10
 
+// scale derived from resolution for timing adjustments (half resolution, min 1)
+#define MATRIX_RESOLUTION_SCALE ((MATRIX_RESOLUTION + 1) / 2)
+
 // internal high-resolution matrix dimensions
 #define MATRIX_INTERNAL_WIDTH  (MATRIX_WIDTH  * MATRIX_RESOLUTION)
 #define MATRIX_INTERNAL_HEIGHT (MATRIX_HEIGHT * MATRIX_RESOLUTION)
@@ -41,7 +44,7 @@ private:
     // Animation delay in ms
     #define ANIM_DELAY 10
     // Animation delay for hourglass fill
-    #define SPAWN_DELAY 1000
+    #define SPAWN_DELAY (1000 / MATRIX_RESOLUTION_SCALE)
 
 
     #define NUM_LEDS (MATRIX_WIDTH * MATRIX_HEIGHT)

--- a/src/led.h
+++ b/src/led.h
@@ -43,8 +43,8 @@ private:
     #define MILLIS_PER_FRAME (1000 / FRAMERATE)
     // Animation delay in ms
     #define ANIM_DELAY 10
-    // Animation delay for hourglass fill
-    #define SPAWN_DELAY (1000 / MATRIX_RESOLUTION_SCALE)
+    // Delay between spawning new cells (scaled with resolution and slower than animation)
+    #define SPAWN_DELAY (MATRIX_RESOLUTION_SCALE * 100)
 
 
     #define NUM_LEDS (MATRIX_WIDTH * MATRIX_HEIGHT)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,8 +35,7 @@ void setup()
 
     setupLocalApi(&wk);
 
-
-    matrix.clear();
+    matrix.init();
 
     // test sets
     // matrix.setCell(Coord(0, 0), CELL_REVIEW, V);

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -1,37 +1,45 @@
 #include "matrix.h"
 
-Matrix::Matrix(WaniKani *wk) { this->wk = wk; }
+Matrix::Matrix(WaniKani *wk) {
+  this->wk = wk;
+  cells = nullptr;
+}
+
+void Matrix::init() {
+  cells = new Cell[MATRIX_INTERNAL_WIDTH * MATRIX_INTERNAL_HEIGHT];
+  clear();
+}
 
 void Matrix::clear() {
-  for (uint8_t x = 0; x < MATRIX_WIDTH; ++x)
-    for (uint8_t y = 0; y < MATRIX_HEIGHT; ++y)
-      cells[x][y] = Cell();
+  for (uint8_t x = 0; x < MATRIX_INTERNAL_WIDTH; ++x)
+    for (uint8_t y = 0; y < MATRIX_INTERNAL_HEIGHT; ++y)
+      cellAt(x, y) = Cell();
 }
 
 void Matrix::setCell(Coord coord, CellType type, uint8_t value) {
   const uint8_t x = coord.x;
   const uint8_t y = coord.y;
-  if (x >= MATRIX_WIDTH || y >= MATRIX_HEIGHT)
+  if (x >= MATRIX_INTERNAL_WIDTH || y >= MATRIX_INTERNAL_HEIGHT)
     return;
-  cells[x][y].type = type;
-  cells[x][y].value = value;
+  cellAt(x, y).type = type;
+  cellAt(x, y).value = value;
   switch (type) {
   case CELL_LESSON:
-    cells[x][y].hue = HUE_LESSON;
+    cellAt(x, y).hue = HUE_LESSON;
     break;
   case CELL_REVIEW:
-    cells[x][y].hue = HUE_REVIEW;
+    cellAt(x, y).hue = HUE_REVIEW;
     break;
   case CELL_REVIEW_FUTURE:
-    cells[x][y].hue = HUE_REVIEW_FUTURE;
+    cellAt(x, y).hue = HUE_REVIEW_FUTURE;
     break;
   case CELL_EMPTY:
   default:
-    cells[x][y].hue = 0;
+    cellAt(x, y).hue = 0;
     break;
   }
 
-  cells[x][y].hue += random(-hueRandomness, hueRandomness + 1);
+  cellAt(x, y).hue += random(-hueRandomness, hueRandomness + 1);
 }
 
 void Matrix::setCell(Coord coord, CellType type) {
@@ -39,21 +47,45 @@ void Matrix::setCell(Coord coord, CellType type) {
 }
 
 Cell *Matrix::getCell(uint8_t x, uint8_t y) {
-  if (x >= MATRIX_WIDTH || y >= MATRIX_HEIGHT || x < 0 || y < 0)
+  if (x >= MATRIX_INTERNAL_WIDTH || y >= MATRIX_INTERNAL_HEIGHT || x < 0 || y < 0)
     return nullptr;
-  return &cells[x][y];
+  return &cellAt(x, y);
 }
 
 Cell *Matrix::getCell(Coord coord) { return this->getCell(coord.x, coord.y); }
 
 const Cell *Matrix::getCell(uint8_t x, uint8_t y) const {
-  if (x >= MATRIX_WIDTH || y >= MATRIX_HEIGHT || x < 0 || y < 0)
+  if (x >= MATRIX_INTERNAL_WIDTH || y >= MATRIX_INTERNAL_HEIGHT || x < 0 || y < 0)
     return nullptr;
-  return &cells[x][y];
+  return &cellAt(x, y);
 }
 
 const Cell *Matrix::getCell(Coord coord) const {
   return this->getCell(coord.x, coord.y);
+}
+
+CRGB Matrix::getLedColor(uint8_t x, uint8_t y) const {
+  uint32_t r = 0, g = 0, b = 0;
+  for (uint8_t sx = 0; sx < MATRIX_RESOLUTION; ++sx) {
+    for (uint8_t sy = 0; sy < MATRIX_RESOLUTION; ++sy) {
+      uint8_t ix = x * MATRIX_RESOLUTION + sx;
+      uint8_t iy = y * MATRIX_RESOLUTION + sy;
+      const Cell &cell = cellAt(ix, iy);
+      if (cell.type != CELL_EMPTY) {
+        CRGB tmp;
+        tmp.setHSV(cell.hue, S, cell.value);
+        r += tmp.r;
+        g += tmp.g;
+        b += tmp.b;
+      }
+    }
+  }
+  uint16_t total = MATRIX_RESOLUTION * MATRIX_RESOLUTION;
+  CRGB out;
+  out.r = r / total;
+  out.g = g / total;
+  out.b = b / total;
+  return out;
 }
 
 /**
@@ -65,9 +97,9 @@ void Matrix::simulationStep() {
   if (calls < MATRIX_STEP_FRAMES)
     return;
 
-  for (uint8_t x = 0; x < MATRIX_WIDTH; ++x) {
-    for (uint8_t y = 0; y < MATRIX_HEIGHT; ++y) {
-      Cell cell = cells[x][y];
+  for (uint8_t x = 0; x < MATRIX_INTERNAL_WIDTH; ++x) {
+    for (uint8_t y = 0; y < MATRIX_INTERNAL_HEIGHT; ++y) {
+      Cell cell = cellAt(x, y);
       Coord coord = Coord(x, y);
       this->generalCellLogic(coord);
       if (cell.type == CELL_LESSON) {
@@ -100,7 +132,7 @@ void Matrix::generalCellLogic(Coord coord) {
   // If blocked below, try diagonals
   Cell *downLeft =
       (y > 0 && x > 0) ? getCell((uint8_t)(x - 1), (uint8_t)(y - 1)) : nullptr;
-  Cell *downRight = (y > 0 && (uint8_t)(x + 1) < MATRIX_WIDTH)
+  Cell *downRight = (y > 0 && (uint8_t)(x + 1) < MATRIX_INTERNAL_WIDTH)
                         ? getCell((uint8_t)(x + 1), (uint8_t)(y - 1))
                         : nullptr;
 
@@ -146,17 +178,23 @@ void Matrix::updateReviewFutureRow() {
     if (reviewsHour > maxReviews)
       maxReviews = reviewsHour;
   }
+  uint8_t startY = (MATRIX_HEIGHT - 1) * MATRIX_RESOLUTION;
   if (maxReviews == 0) {
     for (uint8_t x = 0; x < MATRIX_WIDTH; ++x)
-      this->setCell(Coord(x, MATRIX_HEIGHT - 1), CELL_REVIEW_FUTURE, 0);
+      for (uint8_t sx = 0; sx < MATRIX_RESOLUTION; ++sx)
+        for (uint8_t sy = 0; sy < MATRIX_RESOLUTION; ++sy)
+          this->setCell(Coord(x * MATRIX_RESOLUTION + sx, startY + sy),
+                        CELL_REVIEW_FUTURE, 0);
     return;
   }
 
   for (uint8_t x = 0; x < MATRIX_WIDTH; ++x) {
-    Coord coord = Coord(x, MATRIX_HEIGHT - 1);
     uint16_t reviewsHour = this->getScaledFutureReview(x);
     uint8_t normalizedBrightness = (reviewsHour * V) / maxReviews;
-    this->setCell(coord, CELL_REVIEW_FUTURE, normalizedBrightness);
+    for (uint8_t sx = 0; sx < MATRIX_RESOLUTION; ++sx)
+      for (uint8_t sy = 0; sy < MATRIX_RESOLUTION; ++sy)
+        this->setCell(Coord(x * MATRIX_RESOLUTION + sx, startY + sy),
+                      CELL_REVIEW_FUTURE, normalizedBrightness);
   }
 }
 
@@ -190,33 +228,32 @@ uint16_t Matrix::getScaledFutureReview(uint8_t x) {
 
 ReviewLessonCounts Matrix::getReviewLessonCounts() const {
   ReviewLessonCounts counts;
-
-  for (const auto &cell : cells) {
-    for (auto c : cell) {
+  for (uint8_t x = 0; x < MATRIX_INTERNAL_WIDTH; ++x) {
+    for (uint8_t y = 0; y < MATRIX_INTERNAL_HEIGHT; ++y) {
+      const Cell &c = cellAt(x, y);
       if (c.type == CELL_LESSON)
         ++counts.lessons;
       else if (c.type == CELL_REVIEW)
         ++counts.reviews;
     }
   }
-
   return counts;
 }
 
 Coord Matrix::getRandomCellCoord(CellType type) const {
   uint16_t total = 0;
-  for (uint8_t x = 0; x < MATRIX_WIDTH; ++x)
-    for (uint8_t y = 0; y < MATRIX_HEIGHT; ++y)
-      if (cells[x][y].type == type)
+  for (uint8_t x = 0; x < MATRIX_INTERNAL_WIDTH; ++x)
+    for (uint8_t y = 0; y < MATRIX_INTERNAL_HEIGHT; ++y)
+      if (cellAt(x, y).type == type)
         ++total;
 
   if (total == 0)
     return Coord(0, 0);
 
   uint16_t target = random(total);
-  for (uint8_t x = 0; x < MATRIX_WIDTH; ++x) {
-    for (uint8_t y = 0; y < MATRIX_HEIGHT; ++y) {
-      if (cells[x][y].type == type) {
+  for (uint8_t x = 0; x < MATRIX_INTERNAL_WIDTH; ++x) {
+    for (uint8_t y = 0; y < MATRIX_INTERNAL_HEIGHT; ++y) {
+      if (cellAt(x, y).type == type) {
         if (target == 0)
           return Coord(x, y);
         --target;
@@ -237,25 +274,25 @@ bool Matrix::removeRandomCell(CellType type) {
 
 void Matrix::spawnCellAtTop(CellType type, uint8_t value) {
   // Choose a starting column around the center
-  uint8_t startX = MATRIX_WIDTH / 2;
-  if ((MATRIX_WIDTH & 1) == 0)
+  uint8_t startX = MATRIX_INTERNAL_WIDTH / 2;
+  if ((MATRIX_INTERNAL_WIDTH & 1) == 0)
     startX = (random(2) == 0) ? startX : (uint8_t)(startX - 1);
 
-  for (int8_t y = MATRIX_HEIGHT - 1; y >= 0; --y) {
+  for (int16_t y = MATRIX_INTERNAL_HEIGHT - 1; y >= 0; --y) {
     bool rightFirst = random(2);
-    for (uint8_t offset = 0; offset < MATRIX_WIDTH; ++offset) {
+      for (uint8_t offset = 0; offset < MATRIX_INTERNAL_WIDTH; ++offset) {
       int16_t x = startX + (rightFirst ? 1 : -1) * offset;
-      if (x >= 0 && x < MATRIX_WIDTH &&
-          (cells[x][y].type == CELL_EMPTY ||
-           cells[x][y].type == CELL_REVIEW_FUTURE)) {
+      if (x >= 0 && x < MATRIX_INTERNAL_WIDTH &&
+          (cellAt(x, y).type == CELL_EMPTY ||
+           cellAt(x, y).type == CELL_REVIEW_FUTURE)) {
         setCell(Coord(x, y), type, value);
         return;
       }
       if (offset != 0) {
         x = startX - (rightFirst ? 1 : -1) * offset;
-        if (x >= 0 && x < MATRIX_WIDTH &&
-            (cells[x][y].type == CELL_EMPTY ||
-             cells[x][y].type == CELL_REVIEW_FUTURE)) {
+        if (x >= 0 && x < MATRIX_INTERNAL_WIDTH &&
+            (cellAt(x, y).type == CELL_EMPTY ||
+             cellAt(x, y).type == CELL_REVIEW_FUTURE)) {
           setCell(Coord(x, y), type, value);
           return;
         }
@@ -265,23 +302,6 @@ void Matrix::spawnCellAtTop(CellType type, uint8_t value) {
   }
 }
 
-void Matrix::setBrightnessOne(CellType type, uint8_t value) {
-  for (uint8_t x = 0; x < MATRIX_WIDTH; ++x) {
-    for (uint8_t y = 0; y < MATRIX_HEIGHT; ++y) {
-      if (cells[x][y].type == type) {
-        cells[x][y].value = value;
-        return;
-      }
-    }
-  }
-}
-
-void Matrix::setBrightnessAll(CellType type, uint8_t value) {
-  for (uint8_t x = 0; x < MATRIX_WIDTH; ++x)
-    for (uint8_t y = 0; y < MATRIX_HEIGHT; ++y)
-      if (cells[x][y].type == type)
-        cells[x][y].value = value;
-}
 
 void Matrix::checkReviewLessonCounts() {
   static ulong lastSpawn = 0;
@@ -298,32 +318,8 @@ void Matrix::checkReviewLessonCounts() {
     wkReviews = FRAME_FULL;
 
   auto process = [&](CellType type, int16_t count, uint16_t cellCount) {
-    if (count == 0) {
-      if (cellCount > 0)
-        removeRandomCell(type);
-      return;
-    }
-
-    if (count < ITEMS_PER_PIXEL) {
-      if (cellCount == 0) {
-        if (millis() - lastSpawn >= SPAWN_DELAY) {
-          uint8_t brightness = (count * V) / ITEMS_PER_PIXEL;
-          spawnCellAtTop(type, brightness);
-          lastSpawn = millis();
-        }
-      } else if (cellCount == 1) {
-        uint8_t brightness = (count * V) / ITEMS_PER_PIXEL;
-        setBrightnessOne(type, brightness);
-      } else // cellCount > 1
-      {
-        removeRandomCell(type);
-      }
-      return;
-    }
-
-    // count >= ITEMS_PER_PIXEL
-    setBrightnessAll(type, V);
-    uint16_t requiredCells = count / ITEMS_PER_PIXEL;
+    uint32_t cellsPerPixel = MATRIX_RESOLUTION * MATRIX_RESOLUTION;
+    uint32_t requiredCells = ((uint32_t)count * cellsPerPixel) / ITEMS_PER_PIXEL;
     if (cellCount > requiredCells) {
       removeRandomCell(type);
       return;

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -295,29 +295,17 @@ bool Matrix::removeRandomCell(CellType type) {
 }
 
 void Matrix::spawnCellAtTop(CellType type, uint8_t value) {
-  // Choose a starting column around the center
-  uint8_t startX = MATRIX_INTERNAL_WIDTH / 2;
-  if ((MATRIX_INTERNAL_WIDTH & 1) == 0)
-    startX = (random(2) == 0) ? startX : (uint8_t)(startX - 1);
+  // Choose a random starting column
+  uint8_t startX = random(MATRIX_INTERNAL_WIDTH);
+  // Skip the top review-future row (reserved band at the top)
+  int16_t topY = MATRIX_INTERNAL_HEIGHT - MATRIX_RESOLUTION - 1;
 
-  for (int16_t y = MATRIX_INTERNAL_HEIGHT - 1; y >= 0; --y) {
-    bool rightFirst = random(2);
-      for (uint8_t offset = 0; offset < MATRIX_INTERNAL_WIDTH; ++offset) {
-      int16_t x = startX + (rightFirst ? 1 : -1) * offset;
-      if (x >= 0 && x < MATRIX_INTERNAL_WIDTH &&
-          (cellAt(x, y).type == CELL_EMPTY ||
-           cellAt(x, y).type == CELL_REVIEW_FUTURE)) {
+  for (int16_t y = topY; y >= 0; --y) {
+    for (uint8_t offset = 0; offset < MATRIX_INTERNAL_WIDTH; ++offset) {
+      uint8_t x = (startX + offset) % MATRIX_INTERNAL_WIDTH;
+      if (cellAt(x, y).type == CELL_EMPTY) {
         setCell(Coord(x, y), type, value);
         return;
-      }
-      if (offset != 0) {
-        x = startX - (rightFirst ? 1 : -1) * offset;
-        if (x >= 0 && x < MATRIX_INTERNAL_WIDTH &&
-            (cellAt(x, y).type == CELL_EMPTY ||
-             cellAt(x, y).type == CELL_REVIEW_FUTURE)) {
-          setCell(Coord(x, y), type, value);
-          return;
-        }
       }
     }
     // row is full, try the next row down

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -182,9 +182,12 @@ void Matrix::updateReviewFutureRow() {
   if (maxReviews == 0) {
     for (uint8_t x = 0; x < MATRIX_WIDTH; ++x)
       for (uint8_t sx = 0; sx < MATRIX_RESOLUTION; ++sx)
-        for (uint8_t sy = 0; sy < MATRIX_RESOLUTION; ++sy)
-          this->setCell(Coord(x * MATRIX_RESOLUTION + sx, startY + sy),
-                        CELL_REVIEW_FUTURE, 0);
+        for (uint8_t sy = 0; sy < MATRIX_RESOLUTION; ++sy) {
+          Coord c(x * MATRIX_RESOLUTION + sx, startY + sy);
+          Cell *cell = getCell(c);
+          if (cell && (cell->type == CELL_EMPTY || cell->type == CELL_REVIEW_FUTURE))
+            setCell(c, CELL_REVIEW_FUTURE, 0);
+        }
     return;
   }
 
@@ -192,9 +195,12 @@ void Matrix::updateReviewFutureRow() {
     uint16_t reviewsHour = this->getScaledFutureReview(x);
     uint8_t normalizedBrightness = (reviewsHour * V) / maxReviews;
     for (uint8_t sx = 0; sx < MATRIX_RESOLUTION; ++sx)
-      for (uint8_t sy = 0; sy < MATRIX_RESOLUTION; ++sy)
-        this->setCell(Coord(x * MATRIX_RESOLUTION + sx, startY + sy),
-                      CELL_REVIEW_FUTURE, normalizedBrightness);
+      for (uint8_t sy = 0; sy < MATRIX_RESOLUTION; ++sy) {
+        Coord c(x * MATRIX_RESOLUTION + sx, startY + sy);
+        Cell *cell = getCell(c);
+        if (cell && (cell->type == CELL_EMPTY || cell->type == CELL_REVIEW_FUTURE))
+          setCell(c, CELL_REVIEW_FUTURE, normalizedBrightness);
+      }
   }
 }
 

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -66,6 +66,7 @@ const Cell *Matrix::getCell(Coord coord) const {
 
 CRGB Matrix::getLedColor(uint8_t x, uint8_t y) const {
   uint32_t r = 0, g = 0, b = 0;
+  uint16_t lit = 0;
   for (uint8_t sx = 0; sx < MATRIX_RESOLUTION; ++sx) {
     for (uint8_t sy = 0; sy < MATRIX_RESOLUTION; ++sy) {
       uint8_t ix = x * MATRIX_RESOLUTION + sx;
@@ -77,14 +78,29 @@ CRGB Matrix::getLedColor(uint8_t x, uint8_t y) const {
         r += tmp.r;
         g += tmp.g;
         b += tmp.b;
+        ++lit;
       }
     }
   }
+  if (lit == 0)
+    return CRGB::Black;
+
   uint16_t total = MATRIX_RESOLUTION * MATRIX_RESOLUTION;
   CRGB out;
   out.r = r / total;
   out.g = g / total;
   out.b = b / total;
+
+  const uint8_t MIN_BRIGHTNESS = 50;
+  uint8_t maxVal = max(out.r, max(out.g, out.b));
+  uint16_t target = MIN_BRIGHTNESS +
+                    ((uint16_t)maxVal * (255 - MIN_BRIGHTNESS)) / 255;
+  if (maxVal > 0) {
+    out.r = (out.r * target) / maxVal;
+    out.g = (out.g * target) / maxVal;
+    out.b = (out.b * target) / maxVal;
+  }
+
   return out;
 }
 

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -46,6 +46,7 @@ class Matrix
 {
 public:
     Matrix(WaniKani* wk);
+    void init();
     void clear();
     void setCell(Coord coord, CellType type, uint8_t value);
     void setCell(Coord coord, CellType type);
@@ -53,6 +54,8 @@ public:
     Cell* getCell(uint8_t x, uint8_t y);
     const Cell* getCell(Coord coord) const;
     const Cell* getCell(uint8_t x, uint8_t y) const;
+    // Get aggregated color for the physical LED at (x, y)
+    CRGB getLedColor(uint8_t x, uint8_t y) const;
     static uint8_t width() { return MATRIX_WIDTH; }
     static uint8_t height() { return MATRIX_HEIGHT; }
     void simulationStep();
@@ -63,8 +66,14 @@ public:
 private:
     WaniKani* wk;
     const uint8_t hueRandomness = 15;  // add a random value between +- this to the hue, for some variation
-    // 0, 0 is bottom left
-    Cell cells[MATRIX_WIDTH][MATRIX_HEIGHT];
+    // 0, 0 is bottom left in high resolution
+    Cell* cells = nullptr;
+    inline Cell& cellAt(uint8_t x, uint8_t y) {
+        return cells[x + y * MATRIX_INTERNAL_WIDTH];
+    }
+    inline const Cell& cellAt(uint8_t x, uint8_t y) const {
+        return cells[x + y * MATRIX_INTERNAL_WIDTH];
+    }
     void generalCellLogic(Coord coord);
     void lessonCellLogic(Coord coord);
     void reviewCellLogic(Coord coord);
@@ -76,8 +85,6 @@ private:
     Coord getRandomCellCoord(CellType type) const;
     bool removeRandomCell(CellType type);
     void spawnCellAtTop(CellType type, uint8_t value);
-    void setBrightnessOne(CellType type, uint8_t value);
-    void setBrightnessAll(CellType type, uint8_t value);
 
 
 };

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -6,7 +6,8 @@
 #include "wanikani.h"
 
 #define ONE_TO_ONE_HOURS 3  // number of pixels to light for 1 hour, rest will be squished to 24h
-#define MATRIX_SIMULATION_FPS 3
+// run the simulation faster for higher internal resolution (half the resolution factor)
+#define MATRIX_SIMULATION_FPS (3 * MATRIX_RESOLUTION_SCALE)
 
 
 #define MATRIX_SIMULATION_MILLIS (1000 / MATRIX_SIMULATION_FPS)

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -6,12 +6,14 @@
 #include "wanikani.h"
 
 #define ONE_TO_ONE_HOURS 3  // number of pixels to light for 1 hour, rest will be squished to 24h
-// run the simulation faster for higher internal resolution (half the resolution factor)
-#define MATRIX_SIMULATION_FPS (3 * MATRIX_RESOLUTION_SCALE)
-
-
+// run the simulation faster for higher internal resolution
+#define MATRIX_SIMULATION_FPS (15 * MATRIX_RESOLUTION_SCALE)
 #define MATRIX_SIMULATION_MILLIS (1000 / MATRIX_SIMULATION_FPS)
-#define MATRIX_STEP_FRAMES (MATRIX_SIMULATION_MILLIS / MILLIS_PER_FRAME)
+// ensure at least one simulation step per rendered frame
+#define MATRIX_STEP_FRAMES \
+    ((MATRIX_SIMULATION_MILLIS / MILLIS_PER_FRAME) > 0 \
+         ? (MATRIX_SIMULATION_MILLIS / MILLIS_PER_FRAME) \
+         : 1)
 
 enum CellType
 {


### PR DESCRIPTION
## Summary
- simulate LED matrix at configurable 10x resolution for smoother animations
- compute LED colors by averaging high-res subcells
- adjust review/lesson count handling for subpixel grid
- initialize matrix in explicit init() instead of constructor

## Testing
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_68a8a1866dd88332badd16ce470cc675