### PR TITLE
feat: make lesson cells slip further

### DIFF
--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -354,6 +354,10 @@ void Matrix::spawnCellAtTop(CellType type, uint8_t value) {
   enum SpawnState { STAY, SEARCH };
   static SpawnState state = SEARCH;
 
+  if (type == CELL_LESSON) {
+    state = STAY;
+  }
+
   uint8_t startX;
   if (state == STAY && targetX >= 0) {
     startX = targetX;
@@ -370,7 +374,8 @@ void Matrix::spawnCellAtTop(CellType type, uint8_t value) {
       if (x >= 0 && x < MATRIX_INTERNAL_WIDTH && cellAt(x, y).type == CELL_EMPTY) {
         setCell(Coord(x, y), type, value);
         targetX = x;
-        state = (random(100) < STAY_PERCENTAGE) ? STAY : SEARCH;
+        if (type == CELL_REVIEW)
+          state = (random(100) < STAY_PERCENTAGE) ? STAY : SEARCH;
         return;
       }
       if (offset != 0) {
@@ -378,7 +383,8 @@ void Matrix::spawnCellAtTop(CellType type, uint8_t value) {
         if (x >= 0 && x < MATRIX_INTERNAL_WIDTH && cellAt(x, y).type == CELL_EMPTY) {
           setCell(Coord(x, y), type, value);
           targetX = x;
-          state = (random(100) < STAY_PERCENTAGE) ? STAY : SEARCH;
+          if (type == CELL_REVIEW)
+            state = (random(100) < STAY_PERCENTAGE) ? STAY : SEARCH;
           return;
         }
       }

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -190,7 +190,7 @@ void Matrix::lessonCellLogic(Coord coord) {
   const uint8_t y = coord.y;
 
   Cell *below = (y > 0) ? getCell(x, (uint8_t)(y - 1)) : nullptr;
-  if (!below || below->type != CELL_REVIEW)
+  if (!below || below->type == CELL_EMPTY)
     return;
 
   Cell *downLeft1 =
@@ -206,10 +206,10 @@ void Matrix::lessonCellLogic(Coord coord) {
           ? getCell((uint8_t)(x + 2), (uint8_t)(y - 1))
           : nullptr;
 
-  const bool canSlipLeft = (downLeft1 && downLeft1->type == CELL_REVIEW &&
+  const bool canSlipLeft = (downLeft1 && downLeft1->type != CELL_EMPTY &&
                             downLeft2 && downLeft2->type == CELL_EMPTY);
   const bool canSlipRight =
-      (downRight1 && downRight1->type == CELL_REVIEW && downRight2 &&
+      (downRight1 && downRight1->type != CELL_EMPTY && downRight2 &&
        downRight2->type == CELL_EMPTY);
 
   if (canSlipLeft && canSlipRight) {

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -19,6 +19,7 @@ void Matrix::clear() {
 void Matrix::setCell(Coord coord, CellType type, uint8_t value) {
   const uint8_t x = coord.x;
   const uint8_t y = coord.y;
+
   if (x >= MATRIX_INTERNAL_WIDTH || y >= MATRIX_INTERNAL_HEIGHT)
     return;
   cellAt(x, y).type = type;
@@ -188,6 +189,16 @@ void Matrix::lessonCellLogic(Coord coord) {
   const uint8_t x = coord.x;
   const uint8_t y = coord.y;
 
+  Cell *below = (y > 0) ? getCell(x, (uint8_t)(y - 1)) : nullptr;
+  if (!below || below->type != CELL_REVIEW)
+    return;
+
+  Cell *downLeft1 =
+      (y > 0 && x > 0) ? getCell((uint8_t)(x - 1), (uint8_t)(y - 1)) : nullptr;
+  Cell *downRight1 =
+      (y > 0 && (uint8_t)(x + 1) < MATRIX_INTERNAL_WIDTH)
+          ? getCell((uint8_t)(x + 1), (uint8_t)(y - 1))
+          : nullptr;
   Cell *downLeft2 =
       (y > 0 && x > 1) ? getCell((uint8_t)(x - 2), (uint8_t)(y - 1)) : nullptr;
   Cell *downRight2 =
@@ -195,20 +206,23 @@ void Matrix::lessonCellLogic(Coord coord) {
           ? getCell((uint8_t)(x + 2), (uint8_t)(y - 1))
           : nullptr;
 
-  const bool leftFree = (downLeft2 && downLeft2->type == CELL_EMPTY);
-  const bool rightFree = (downRight2 && downRight2->type == CELL_EMPTY);
+  const bool canSlipLeft = (downLeft1 && downLeft1->type == CELL_REVIEW &&
+                            downLeft2 && downLeft2->type == CELL_EMPTY);
+  const bool canSlipRight =
+      (downRight1 && downRight1->type == CELL_REVIEW && downRight2 &&
+       downRight2->type == CELL_EMPTY);
 
-  if (leftFree && rightFree) {
+  if (canSlipLeft && canSlipRight) {
     if ((millis() & 1) == 0)
       *downLeft2 = *cur;
     else
       *downRight2 = *cur;
 
     *cur = Cell();
-  } else if (leftFree) {
+  } else if (canSlipLeft) {
     *downLeft2 = *cur;
     *cur = Cell();
-  } else if (rightFree) {
+  } else if (canSlipRight) {
     *downRight2 = *cur;
     *cur = Cell();
   }

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -180,7 +180,39 @@ void Matrix::generalCellLogic(Coord coord) {
   // else: stays in place (rests on floor or another cell)
 }
 
-void Matrix::lessonCellLogic(Coord coord) {}
+void Matrix::lessonCellLogic(Coord coord) {
+  Cell *cur = getCell(coord);
+  if (!cur || cur->type != CELL_LESSON)
+    return;
+
+  const uint8_t x = coord.x;
+  const uint8_t y = coord.y;
+
+  Cell *downLeft2 =
+      (y > 0 && x > 1) ? getCell((uint8_t)(x - 2), (uint8_t)(y - 1)) : nullptr;
+  Cell *downRight2 =
+      (y > 0 && (uint8_t)(x + 2) < MATRIX_INTERNAL_WIDTH)
+          ? getCell((uint8_t)(x + 2), (uint8_t)(y - 1))
+          : nullptr;
+
+  const bool leftFree = (downLeft2 && downLeft2->type == CELL_EMPTY);
+  const bool rightFree = (downRight2 && downRight2->type == CELL_EMPTY);
+
+  if (leftFree && rightFree) {
+    if ((millis() & 1) == 0)
+      *downLeft2 = *cur;
+    else
+      *downRight2 = *cur;
+
+    *cur = Cell();
+  } else if (leftFree) {
+    *downLeft2 = *cur;
+    *cur = Cell();
+  } else if (rightFree) {
+    *downRight2 = *cur;
+    *cur = Cell();
+  }
+}
 
 void Matrix::reviewCellLogic(Coord coord) {}
 


### PR DESCRIPTION
## Summary
- allow lesson cells to slip two spaces diagonally when blocked

## Testing
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_68aafb38196083328132ccd13f9def98