### PR TITLE
Add simple configuration web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ The device exposes a small HTTP server that allows several runtime constants
 to be adjusted without recompiling. These values are persisted in the ESP32's
 non‑volatile storage so they survive power cycles.
 
+### Web interface
+
+Visit `http://<device-ip>/` in a browser to access a lightweight configuration
+page. It fetches the current settings and lets you update them using a simple
+form instead of manual `curl` commands.
+
 ### Updating parameters
 
 Send a `GET` request to `/config` with one or more URL parameters. Supported
@@ -38,6 +44,8 @@ curl "http://<device-ip>/config?wifi_ssid=Home&wifi_pass=secret&wifi_backup_ssid
 The endpoint responds with a JSON object containing the current settings. If
 called without parameters, it simply returns the existing configuration with any
 password fields redacted.
+
+You can find reference HSV hue values in the [FastLED HSV Colors chart](https://github.com/FastLED/FastLED/wiki/FastLED-HSV-Colors).
 
 ### Resetting to defaults
 

--- a/src/local_api.cpp
+++ b/src/local_api.cpp
@@ -3,9 +3,79 @@
 #include "local_api.h"
 #include "runtime_config.h"
 #include "utils.h"
+#include <pgmspace.h>
 
 static WaniKani* g_wk = nullptr;
 static WebServer server(80);
+
+static const char CONFIG_HTML[] PROGMEM = R"rawliteral(
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Frame of Enlightenment Config</title>
+<style>
+body{font-family:Arial,Helvetica,sans-serif;background:#f5f5f5;margin:0;display:flex;justify-content:center;}
+.container{max-width:480px;margin-top:40px;background:#fff;padding:20px;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1);}
+h1{text-align:center;margin-top:0;font-size:1.5em;}
+label{display:block;margin-bottom:12px;}
+input{width:100%;padding:8px;margin-top:4px;box-sizing:border-box;}
+button{margin-top:10px;padding:10px 16px;border:none;border-radius:4px;background:#007bff;color:#fff;cursor:pointer;}
+button#reset{background:#dc3545;}
+button:hover{opacity:0.9;}
+</style>
+</head>
+<body>
+<div class="container">
+<h1>Frame of Enlightenment config</h1>
+<form id="cfgForm">
+<label>Frame Full:<input type="number" id="frame_full" name="frame_full"></label>
+<label>Framerate:<input type="number" id="framerate" name="framerate"></label>
+<label>Min S:<input type="number" id="min_s" name="min_s"></label>
+<label>Min V:<input type="number" id="min_v" name="min_v"></label>
+<label>Hue Lesson:<input type="number" id="hue_lesson" name="hue_lesson"></label>
+<label>Hue Review:<input type="number" id="hue_review" name="hue_review"></label>
+<label>Hue Review Future:<input type="number" id="hue_review_future" name="hue_review_future"></label>
+<label>WiFi SSID:<input type="text" id="wifi_ssid" name="wifi_ssid"></label>
+<label>WiFi Pass:<input type="password" id="wifi_pass" name="wifi_pass"></label>
+<label>WiFi Backup SSID:<input type="text" id="wifi_backup_ssid" name="wifi_backup_ssid"></label>
+<label>WiFi Backup Pass:<input type="password" id="wifi_backup_pass" name="wifi_backup_pass"></label>
+<button type="submit">Save</button>
+</form>
+<button id="reset">Reset to defaults</button>
+<pre id="status"></pre>
+</div>
+<script>
+function load(){
+ fetch('/config').then(r=>r.json()).then(cfg=>{
+  for(const k in cfg){
+   const el=document.getElementById(k);
+   if(el){
+    el.value=(cfg[k]==='***')?'':cfg[k];
+   }
+  }
+ });
+}
+document.getElementById('cfgForm').addEventListener('submit',e=>{
+ e.preventDefault();
+ const data=new FormData(e.target);
+ const params=new URLSearchParams();
+ for(const pair of data.entries()){
+  if(pair[1]) params.append(pair[0], pair[1]);
+ }
+ fetch('/config?'+params.toString()).then(r=>r.json()).then(cfg=>{
+  document.getElementById('status').textContent='Saved';
+  load();
+ });
+});
+document.getElementById('reset').addEventListener('click',()=>{
+ fetch('/config/reset',{method:'POST'}).then(()=>{load();});
+});
+load();
+</script>
+</body>
+</html>
+)rawliteral";
 
 static void handleWaniKaniPost()
 {
@@ -30,6 +100,9 @@ void setupLocalApi(WaniKani* wk)
 {
     g_wk = wk;
     server.on("/wanikani_test_data", HTTP_POST, handleWaniKaniPost);
+    server.on("/", HTTP_GET, [](){
+        server.send_P(200, "text/html", CONFIG_HTML);
+    });
     server.on("/config", HTTP_GET, [](){
         bool updated = false;
         bool wifiUpdated = false;


### PR DESCRIPTION
## Summary
- Serve a lightweight styled configuration page at the device root
- Document a FastLED HSV color reference for hue selection

## Testing
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_68ab712191908332a01c2c61951113d1