### PR TITLE
Expose color and resolution settings via API

### DIFF
--- a/src/led.cpp
+++ b/src/led.cpp
@@ -24,8 +24,8 @@ void Led::setup()
 
     Serial.println("LED setup complete");
 
-    // Set a lower brightness to start
-    FastLED.setBrightness(128);
+    // Set full brightness to start
+    FastLED.setBrightness(255);
 }
 
 uint16_t Led::XY(uint8_t x, uint8_t y)
@@ -106,77 +106,6 @@ void Led::printLeds()
  * pixel is a pointer to the individual pixel from Fastled led matrix.
  * If pixel is off, fades it to on at that hue from the beginning.
 */
-void Led::fadeToHue(CRGB* pixel, uint8_t targetHue)
-{
-    if (pixel->getLuma() == 0)
-        fadeOn(pixel, targetHue);
-    else
-    {
-        CHSV hsvPix(rgb2hsv_approximate(*pixel));
-        while (hsvPix.hue != targetHue)
-        {
-            if (hsvPix.hue < targetHue)
-                hsvPix.hue++;
-            else
-                hsvPix.hue--;
-            pixel->setHue(hsvPix.hue);
-            show(ANIM_DELAY * 3);
-        }
-    }
-}
-
-
-void Led::fadeOff(CRGB* pixel)
-{
-    const uint8_t fading = 10; //pixel->getLuma();
-    uint8_t prevLuma = 0;
-    while (pixel->getLuma() > 0)
-    {
-        if (prevLuma == pixel->getLuma())
-        {
-            pixel->setRGB(0, 0, 0);
-            show();
-            return;
-        }
-
-        prevLuma = pixel->getLuma();
-        // Serial.println("fadeOff: " + String(pixel->getLuma()));
-        // fading--;
-        pixel->fadeToBlackBy(fading);
-        show();
-    }
-}
-
-void Led::fadeOn(CRGB* pixel, u8_t hue)
-{
-    if (pixel->getAverageLight() > V / 4)
-        return;
-    pixel->setHue(hue);
-
-    for (int v = 0; v < V; v += 20)
-    {
-        if (v > V) v = V;
-        pixel->setHSV(hue, S, v);
-        show(ANIM_DELAY / 2);
-    }
-    pixel->setHSV(hue, S, V);
-}
-
-/**
- * Show with delay
-*/
-void Led::show()
-{
-    show(ANIM_DELAY);
-}
-
-void Led::show(u16_t delay)
-{
-    FastLED.delay(delay);
-    FastLED.show();
-}
-
-
 void Led::displayMatrix(const Matrix& matrix)
 {
     for (uint8_t x = 0; x < MATRIX_WIDTH; ++x)

--- a/src/led.h
+++ b/src/led.h
@@ -17,7 +17,7 @@
 #define MATRIX_HEIGHT 10  // adjust
 
 // factor by which the simulation matrix is higher resolution than the LED matrix
-#define MATRIX_RESOLUTION 10
+#define MATRIX_RESOLUTION (g_config.matrixResolution)
 
 // scale derived from resolution for timing adjustments (half resolution, min 1)
 #define MATRIX_RESOLUTION_SCALE ((MATRIX_RESOLUTION + 1) / 2)
@@ -36,17 +36,15 @@ private:
     #define COLOR_ORDER GRB
 
     // HSV Saturation
-    #define S 255
+    #define S (g_config.maxS)
     // HSV value (brightness / Luma)
-    #define V 255
+    #define V (g_config.maxV)
 
     #define MIN_S (g_config.minS)
     #define MIN_V (g_config.minV)
 
     #define FRAMERATE (g_config.frameRate)
     #define MILLIS_PER_FRAME (1000 / FRAMERATE)
-    // Animation delay in ms
-    #define ANIM_DELAY 10
     // Animation delay for hourglass fill
     #define SPAWN_DELAY (50 / MATRIX_RESOLUTION_SCALE)
 
@@ -62,11 +60,6 @@ private:
 
     void setup();
     void printLeds();
-    void fadeToHue(CRGB* pixel, uint8_t targetHue);
-    void fadeOn(CRGB* pixel, uint8_t hue);
-    void fadeOff(CRGB* pixel);
-    void show();
-    void show(u16_t delay);
 
     struct lightLedParameters
     {

--- a/src/local_api.cpp
+++ b/src/local_api.cpp
@@ -29,13 +29,13 @@ button:hover{opacity:0.9;}
 <div class="container">
 <h1>Frame of Enlightenment config</h1>
 <form id="cfgForm">
-<label title="Total items to light the entire frame">Frame Full:<input type="number" id="frame_full" name="frame_full"></label>
+<label title="Total items required to light the entire frame">Frame Full:<input type="number" id="frame_full" name="frame_full"></label>
 <label title="Display refresh rate (frames per second)">Framerate:<input type="number" id="framerate" name="framerate"></label>
-<label title="Minimum color saturation">Min S:<input type="number" id="min_s" name="min_s"></label>
-<label title="Minimum brightness value">Min V:<input type="number" id="min_v" name="min_v"></label>
+<label title="Minimum saturation used for animated cells">Minimum Saturation:<input type="number" id="min_s" name="min_s"></label>
+<label title="Base brightness level applied to animated cells">Base Brightness:<input type="number" id="min_v" name="min_v"></label>
 <label title="Base color saturation">Max S:<input type="number" id="max_s" name="max_s"></label>
 <label title="Base brightness value">Max V:<input type="number" id="max_v" name="max_v"></label>
-<label title="Internal resolution multiplier">Matrix Resolution:<input type="number" id="matrix_resolution" name="matrix_resolution"></label>
+<label title="Multiplier for the internal simulation resolution. 10x means 10x higher resolution per axis, so 100 simulated cells per LED">Matrix Resolution:<input type="number" id="matrix_resolution" name="matrix_resolution"></label>
 <label title="Hue for lesson cells">Hue Lesson:<input type="number" id="hue_lesson" name="hue_lesson"></label>
 <label title="Hue for review cells">Hue Review:<input type="number" id="hue_review" name="hue_review"></label>
 <label title="Hue for upcoming reviews">Hue Review Future:<input type="number" id="hue_review_future" name="hue_review_future"></label>

--- a/src/local_api.cpp
+++ b/src/local_api.cpp
@@ -29,17 +29,20 @@ button:hover{opacity:0.9;}
 <div class="container">
 <h1>Frame of Enlightenment config</h1>
 <form id="cfgForm">
-<label>Frame Full:<input type="number" id="frame_full" name="frame_full"></label>
-<label>Framerate:<input type="number" id="framerate" name="framerate"></label>
-<label>Min S:<input type="number" id="min_s" name="min_s"></label>
-<label>Min V:<input type="number" id="min_v" name="min_v"></label>
-<label>Hue Lesson:<input type="number" id="hue_lesson" name="hue_lesson"></label>
-<label>Hue Review:<input type="number" id="hue_review" name="hue_review"></label>
-<label>Hue Review Future:<input type="number" id="hue_review_future" name="hue_review_future"></label>
-<label>WiFi SSID:<input type="text" id="wifi_ssid" name="wifi_ssid"></label>
-<label>WiFi Pass:<input type="password" id="wifi_pass" name="wifi_pass"></label>
-<label>WiFi Backup SSID:<input type="text" id="wifi_backup_ssid" name="wifi_backup_ssid"></label>
-<label>WiFi Backup Pass:<input type="password" id="wifi_backup_pass" name="wifi_backup_pass"></label>
+<label title="Total items to light the entire frame">Frame Full:<input type="number" id="frame_full" name="frame_full"></label>
+<label title="Display refresh rate (frames per second)">Framerate:<input type="number" id="framerate" name="framerate"></label>
+<label title="Minimum color saturation">Min S:<input type="number" id="min_s" name="min_s"></label>
+<label title="Minimum brightness value">Min V:<input type="number" id="min_v" name="min_v"></label>
+<label title="Base color saturation">Max S:<input type="number" id="max_s" name="max_s"></label>
+<label title="Base brightness value">Max V:<input type="number" id="max_v" name="max_v"></label>
+<label title="Internal resolution multiplier">Matrix Resolution:<input type="number" id="matrix_resolution" name="matrix_resolution"></label>
+<label title="Hue for lesson cells">Hue Lesson:<input type="number" id="hue_lesson" name="hue_lesson"></label>
+<label title="Hue for review cells">Hue Review:<input type="number" id="hue_review" name="hue_review"></label>
+<label title="Hue for upcoming reviews">Hue Review Future:<input type="number" id="hue_review_future" name="hue_review_future"></label>
+<label title="Primary WiFi network name">WiFi SSID:<input type="text" id="wifi_ssid" name="wifi_ssid"></label>
+<label title="Primary WiFi password">WiFi Pass:<input type="password" id="wifi_pass" name="wifi_pass"></label>
+<label title="Backup WiFi network name">WiFi Backup SSID:<input type="text" id="wifi_backup_ssid" name="wifi_backup_ssid"></label>
+<label title="Backup WiFi password">WiFi Backup Pass:<input type="password" id="wifi_backup_pass" name="wifi_backup_pass"></label>
 <button type="submit">Save</button>
 </form>
 <button id="reset">Reset to defaults</button>
@@ -110,6 +113,9 @@ void setupLocalApi(WaniKani* wk)
         if (server.hasArg("framerate")) { g_config.frameRate = server.arg("framerate").toInt(); updated = true; }
         if (server.hasArg("min_s")) { g_config.minS = server.arg("min_s").toInt(); updated = true; }
         if (server.hasArg("min_v")) { g_config.minV = server.arg("min_v").toInt(); updated = true; }
+        if (server.hasArg("max_s")) { g_config.maxS = server.arg("max_s").toInt(); updated = true; }
+        if (server.hasArg("max_v")) { g_config.maxV = server.arg("max_v").toInt(); updated = true; }
+        if (server.hasArg("matrix_resolution")) { g_config.matrixResolution = server.arg("matrix_resolution").toInt(); updated = true; }
         if (server.hasArg("hue_lesson")) { g_config.hueLesson = server.arg("hue_lesson").toInt(); updated = true; }
         if (server.hasArg("hue_review")) { g_config.hueReview = server.arg("hue_review").toInt(); updated = true; }
         if (server.hasArg("hue_review_future")) { g_config.hueReviewFuture = server.arg("hue_review_future").toInt(); updated = true; }
@@ -123,6 +129,9 @@ void setupLocalApi(WaniKani* wk)
         resp += ",\"framerate\":" + String(g_config.frameRate);
         resp += ",\"min_s\":" + String(g_config.minS);
         resp += ",\"min_v\":" + String(g_config.minV);
+        resp += ",\"max_s\":" + String(g_config.maxS);
+        resp += ",\"max_v\":" + String(g_config.maxV);
+        resp += ",\"matrix_resolution\":" + String(g_config.matrixResolution);
         resp += ",\"hue_lesson\":" + String(g_config.hueLesson);
         resp += ",\"hue_review\":" + String(g_config.hueReview);
         resp += ",\"hue_review_future\":" + String(g_config.hueReviewFuture);

--- a/src/runtime_config.cpp
+++ b/src/runtime_config.cpp
@@ -11,6 +11,9 @@ void RuntimeConfig::load() {
     frameRate = prefs.getUInt("frameRate", frameRate);
     minS = prefs.getUChar("minS", minS);
     minV = prefs.getUChar("minV", minV);
+    maxS = prefs.getUChar("maxS", maxS);
+    maxV = prefs.getUChar("maxV", maxV);
+    matrixResolution = prefs.getUChar("matrixRes", matrixResolution);
     hueLesson = prefs.getUChar("hLesson", hueLesson);
     hueReview = prefs.getUChar("hReview", hueReview);
     hueReviewFuture = prefs.getUChar("hReviewF", hueReviewFuture);
@@ -27,6 +30,9 @@ void RuntimeConfig::save() {
     prefs.putUInt("frameRate", frameRate);
     prefs.putUChar("minS", minS);
     prefs.putUChar("minV", minV);
+    prefs.putUChar("maxS", maxS);
+    prefs.putUChar("maxV", maxV);
+    prefs.putUChar("matrixRes", matrixResolution);
     prefs.putUChar("hLesson", hueLesson);
     prefs.putUChar("hReview", hueReview);
     prefs.putUChar("hReviewF", hueReviewFuture);
@@ -42,6 +48,9 @@ void RuntimeConfig::reset() {
     frameRate = 60;
     minS = 50;
     minV = 20;
+    maxS = 255;
+    maxV = 255;
+    matrixResolution = 10;
     hueLesson = 220;
     hueReview = 142;
     hueReviewFuture = 35;

--- a/src/runtime_config.h
+++ b/src/runtime_config.h
@@ -9,6 +9,9 @@ struct RuntimeConfig {
     uint16_t frameRate = 60;
     uint8_t minS = 50;
     uint8_t minV = 20;
+    uint8_t maxS = 255;
+    uint8_t maxV = 255;
+    uint8_t matrixResolution = 10;
     uint8_t hueLesson = 220;
     uint8_t hueReview = 142;
     uint8_t hueReviewFuture = 35;


### PR DESCRIPTION
## Summary
- Make LED saturation, brightness, and matrix resolution configurable via API and web UI
- Default LEDs to full brightness
- Remove obsolete fade helpers and ANIM_DELAY macro
- Add tooltips in config page for clarity

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_68ab8cbd6bf08332ac641b6f29abd858