### PR TITLE
Add presence detection with day/night logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,27 @@ curl -X POST "http://<device-ip>/config/reset"
 
 All values are reset and persisted immediately.
 
+## Presence Detection (optional)
+
+The project can automatically enable the LEDs only when someone is nearby and
+turn them off when the room is empty. Presence detection also takes ambient
+light into account:
+
+- **Daytime:** LEDs remain on for a few minutes after motion stops.
+- **Nighttime:** LEDs turn off immediately once no motion is detected.
+
+### Wiring
+
+1. **PIR motion sensor (HC‑SR501 or similar)**
+   - VCC → 5V
+   - GND → GND
+   - OUT → GPIO 25
+2. **Light sensor (LDR)**
+   - Create a voltage divider: 3.3V → LDR → GPIO 34 → 10 kΩ resistor → GND
+
+### Enabling
+
+Presence detection is compiled in by defining the `ENABLE_PRESENCE` build flag.
+It is enabled in `platformio.ini` and can be disabled by removing the flag or
+passing `-U ENABLE_PRESENCE` when compiling.
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,8 +18,10 @@ debug_tool = esp-prog
 upload_port = /dev/serial/by-id/usb-FTDI_Dual_RS232-HS-if01-port0
 upload_protocol = esp-prog
 build_type = debug
-lib_deps = 
-	Wire
+build_flags =
+        -DENABLE_PRESENCE
+lib_deps =
+        Wire
 	fastled/FastLED@3.7.4
 	fbiego/ESP32Time@2.0.6
 	bblanchon/ArduinoJson@7.4.2

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,8 @@
 #include "local_api.h"
 #include "runtime_config.h"
 #include "config.h"
+#include "presence.h"
+#include <FastLED.h>
 
 // configure WiFi etc. in config.h
 
@@ -17,6 +19,8 @@ int16_t lastLessons = -1;
 WaniKani wk(API_KEY);
 Led led = Led();
 Matrix matrix = Matrix(&wk);
+PresenceDetector presence(25, 34);
+bool g_active = false;
 
 void setup()
 {
@@ -32,6 +36,8 @@ void setup()
 
     sleep(1);
     led.begin();
+
+    presence.init();
 
     setupLocalApi(&wk);
 
@@ -59,22 +65,49 @@ void showWifi()
 void loop()
 {
 
-    showWifi();
+    bool shouldRun = presence.shouldBeActive();
 
-    if (Utils::WiFiConnected())
+    if (shouldRun && !g_active)
     {
+        Serial.println("Presence detected, waking system...");
+        presence.onSystemWake();
+        wk.lastRequestTime = 0;
         wk.refresh();
+        matrix.init();
+        g_active = true;
+    }
+    else if (!shouldRun && g_active)
+    {
+        Serial.println("No presence, sleeping...");
+        FastLED.clear();
+        FastLED.show();
+        g_active = false;
     }
 
-    handleLocalApi();
-
-    EVERY_N_MILLISECONDS(MILLIS_PER_FRAME)
+    if (shouldRun)
     {
-        matrix.simulationStep();
-        matrix.updateReviewFutureRow();
-        matrix.checkReviewLessonCounts();
+        showWifi();
 
-        led.displayMatrix(matrix);
+        if (Utils::WiFiConnected())
+        {
+            wk.refresh();
+        }
+
+        handleLocalApi();
+
+        EVERY_N_MILLISECONDS(MILLIS_PER_FRAME)
+        {
+            matrix.simulationStep();
+            matrix.updateReviewFutureRow();
+            matrix.checkReviewLessonCounts();
+
+            led.displayMatrix(matrix);
+        }
+    }
+    else
+    {
+        handleLocalApi();
+        delay(100);
     }
 }
 

--- a/src/presence.cpp
+++ b/src/presence.cpp
@@ -1,0 +1,43 @@
+#include "presence.h"
+
+#ifdef ENABLE_PRESENCE
+
+PresenceDetector::PresenceDetector(uint8_t pir, uint8_t ldr)
+    : pirPin(pir), ldrPin(ldr) {}
+
+void PresenceDetector::init() {
+    pinMode(pirPin, INPUT);
+}
+
+bool PresenceDetector::hasPresence() {
+    return digitalRead(pirPin) == HIGH;
+}
+
+bool PresenceDetector::isDay() {
+    uint16_t value = analogRead(ldrPin);
+    return value > dayThreshold;
+}
+
+void PresenceDetector::onSystemWake() {
+    lastPresenceTime = millis();
+    lastPresence = true;
+}
+
+bool PresenceDetector::shouldBeActive() {
+    if (hasPresence()) {
+        lastPresenceTime = millis();
+        lastPresence = true;
+        return true;
+    }
+
+    if (lastPresence) {
+        uint32_t timeout = isDay() ? dayTimeout : nightTimeout;
+        if (millis() - lastPresenceTime < timeout) {
+            return true;
+        }
+        lastPresence = false;
+    }
+    return false;
+}
+
+#endif

--- a/src/presence.h
+++ b/src/presence.h
@@ -1,0 +1,36 @@
+#ifndef PRESENCE_H
+#define PRESENCE_H
+
+#include <Arduino.h>
+
+#ifdef ENABLE_PRESENCE
+class PresenceDetector {
+private:
+    uint8_t pirPin;
+    uint8_t ldrPin;
+    const uint16_t dayThreshold = 2048; // ADC midpoint
+    const uint32_t dayTimeout = 300000; // 5 minutes
+    const uint32_t nightTimeout = 0; // immediate
+    bool lastPresence = false;
+    uint32_t lastPresenceTime = 0;
+public:
+    PresenceDetector(uint8_t pir, uint8_t ldr);
+    void init();
+    bool shouldBeActive();
+    void onSystemWake();
+    bool isDay();
+    bool hasPresence();
+};
+#else
+class PresenceDetector {
+public:
+    PresenceDetector(uint8_t, uint8_t) {}
+    void init() {}
+    bool shouldBeActive() { return true; }
+    void onSystemWake() {}
+    bool isDay() { return true; }
+    bool hasPresence() { return true; }
+};
+#endif
+
+#endif


### PR DESCRIPTION
## Summary
- add configurable presence detection module using PIR and LDR sensors
- gate main loop on presence and force API refresh on wake
- document wiring and enable via `ENABLE_PRESENCE` build flag

## Testing
- `platformio run`


------
https://chatgpt.com/codex/tasks/task_e_68ac9ba65628833285ebf2125e0be4e3